### PR TITLE
Made it so extension works even if "Show Header" is unchecked

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -20,19 +20,22 @@ chrome.extension.sendMessage({}, function(response) {
 	}
 }*/
 
+var bossMode = false;
 $("<li id=\"bossbutton\" class=\"toolbar-settings\"><a><span id=\"glypheye\" class=\"glyphicon glyphicon-eye-close\"></span></a></li>" ).insertAfter( $( ".toolbar-settings" ) );
 $("#bossbutton").click(function() {
 	//console.log("boss!");
-		if ($(".site-header").is(":visible") == true){
+		if (!bossMode){
 			$(".site-header").hide();
 			$(".toolbar-wallet").hide();
 			$(".rewards").hide();
 			$("#glypheye").removeClass("glyphicon glyphicon-eye-close").addClass("glyphicon glyphicon-eye-open")
+      bossMode = true;
 		} else {
 			$(".site-header").show();
 			$(".toolbar-wallet").show();
 			$(".rewards").show();
 			$("#glypheye").removeClass("glyphicon glyphicon-eye-open").addClass("glyphicon glyphicon-eye-close")
+      bossMode = false;
 		}
 	}
 )


### PR DESCRIPTION
Here's a screenshot of the `Show Header` option.
![screen shot 2014-10-21 at 8 23 55 am](https://cloud.githubusercontent.com/assets/2916945/4718948/89b68eb8-5925-11e4-90ef-78625d667bf7.png)

Since your extension was using that as a litmus test for when to function, it wouldn't hide anything (rewards, gold, gems, etc) if the `Show Header` option was unchecked.

Moving the conditional to a variable allows it to work even if `Show Header` is unchecked.
